### PR TITLE
Placeholder text setter

### DIFF
--- a/Lexical/LexicalView/LexicalView.swift
+++ b/Lexical/LexicalView/LexicalView.swift
@@ -61,7 +61,7 @@ public extension LexicalViewDelegate {
     self.textView.showsVerticalScrollIndicator = false
     self.textView.clipsToBounds = true
     self.textView.accessibilityTraits = .staticText
-    self.placeholderText = placeholderText
+    self._placeholderText = placeholderText
 
     guard let textStorage = textView.textStorage as? TextStorage else {
       fatalError()
@@ -254,11 +254,23 @@ public extension LexicalViewDelegate {
   }
 
   /// Configure the placeholder text shown by this Lexical view when there is no text.
-  ///
-  /// This needs a refactor. Currently the LexicalView supports setting the placeholder text as part of the initialiser, which
-  /// works correctly. However setting the placeholder text later through this property will not properly proxy it through to the
-  /// TextView. This is a bug and should be fixed.
-  public var placeholderText: LexicalPlaceholderText?
+  private var _placeholderText: LexicalPlaceholderText?
+  public var placeholderText: LexicalPlaceholderText? {
+    get {
+      _placeholderText
+    }
+
+    set {
+      _placeholderText = newValue
+      if let _placeholderText {
+        textView.setPlaceholderText(
+          _placeholderText.text,
+          textColor: _placeholderText.color,
+          font: _placeholderText.font
+        )
+      }
+    }
+  }
 
   /// Returns the current selected text range according to the underlying UITextView.
   ///

--- a/Lexical/TextView/TextView.swift
+++ b/Lexical/TextView/TextView.swift
@@ -361,7 +361,8 @@ protocol LexicalTextViewDelegate: NSObjectProtocol {
       try editor.read {
         if canShowPlaceholder(isComposing: editor.isComposing()) {
           placeholderLabel.isHidden = false
-          layoutIfNeeded()
+          // layoutIfNeeded()
+          layoutSubviews()
         }
       }
     } catch {}


### PR DESCRIPTION
- on setting `LexicalView`'s `placeholderText`, tell its `textView` to set placeholder text
- on `TextView`'s placeholder text update, force `layoutSubviews()` for updating to a correct label layout