### PR TITLE
Non-inline decorators

### DIFF
--- a/Lexical/Core/Nodes/DecoratorNode.swift
+++ b/Lexical/Core/Nodes/DecoratorNode.swift
@@ -101,11 +101,56 @@ open class DecoratorNode: Node {
     return false
   }
 
-  override public final func getPreamble() -> String {
+  open func isInline() -> Bool {
+    return true
+  }
+
+  public final func getUnicodeScalar() -> String {
     guard let unicodeScalar = Unicode.Scalar(NSTextAttachment.character) else {
       return ""
     }
     return String(Character(unicodeScalar))
+  }
+
+  public func getPreambleNewline() -> String {
+    if self.isInline() {
+      return ""
+    }
+
+    guard let prevSibling = getPreviousSibling() else {
+      return ""
+    }
+
+    guard prevSibling is ElementNode || prevSibling is DecoratorNode else {
+      return "\n"
+    }
+
+    return ""
+  }
+
+  override public func getPreamble() -> String {
+    return getPreambleNewline() + getUnicodeScalar()
+  }
+
+  override public func getPostamble() -> String {
+    let nextSibling = getNextSibling()
+    if nextSibling == nil {
+      return ""
+    } else if isInline() {
+      if let nextSiblingAsElement = nextSibling as? ElementNode,
+        !nextSiblingAsElement.isInline()
+      {
+        return "\n"
+      } else if let nextSiblingAsDecorator = nextSibling as? DecoratorNode,
+        !nextSiblingAsDecorator.isInline()
+      {
+        return "\n"
+      } else {
+        return ""
+      }
+    } else {
+      return "\n"
+    }
   }
 
   override public func getAttributedStringAttributes(theme: Theme) -> [NSAttributedString.Key: Any] {

--- a/Lexical/Core/Nodes/DecoratorNode.swift
+++ b/Lexical/Core/Nodes/DecoratorNode.swift
@@ -93,11 +93,11 @@ open class DecoratorNode: Node {
     fatalError("sizeForDecoratorView: base method not extended")
   }
 
-  public func isTopLevel() -> Bool {
+  open func isTopLevel() -> Bool {
     return false
   }
 
-  public func isIsolated() -> Bool {
+  open func isIsolated() -> Bool {
     return false
   }
 

--- a/Lexical/Core/Nodes/DecoratorNode.swift
+++ b/Lexical/Core/Nodes/DecoratorNode.swift
@@ -129,7 +129,7 @@ open class DecoratorNode: Node {
   }
 
   override public func getPreamble() -> String {
-    return getPreambleNewline() + getUnicodeScalar()
+    return getUnicodeScalar()
   }
 
   override public func getPostamble() -> String {

--- a/Lexical/Core/Nodes/DecoratorNode.swift
+++ b/Lexical/Core/Nodes/DecoratorNode.swift
@@ -105,31 +105,11 @@ open class DecoratorNode: Node {
     return true
   }
 
-  public final func getUnicodeScalar() -> String {
+  override public func getPreamble() -> String {
     guard let unicodeScalar = Unicode.Scalar(NSTextAttachment.character) else {
       return ""
     }
     return String(Character(unicodeScalar))
-  }
-
-  public func getPreambleNewline() -> String {
-    if self.isInline() {
-      return ""
-    }
-
-    guard let prevSibling = getPreviousSibling() else {
-      return ""
-    }
-
-    guard prevSibling is ElementNode || prevSibling is DecoratorNode else {
-      return "\n"
-    }
-
-    return ""
-  }
-
-  override public func getPreamble() -> String {
-    return getUnicodeScalar()
   }
 
   override public func getPostamble() -> String {

--- a/Lexical/Core/Nodes/ElementNode.swift
+++ b/Lexical/Core/Nodes/ElementNode.swift
@@ -305,12 +305,12 @@ open class ElementNode: Node {
     }
 
     guard prevSibling is ElementNode || prevSibling is DecoratorNode else {
-      // prev is not an element node. Treat it as inline (TODO: inline handling in decorators)
-      // Since prev is inline but not an element node, and we're not inline, return a newline
+      // prev is not an element/decorator node. Treat it as inline
+      // Since prev is inline but not an element/decorator node, and we're not inline, return a newline
       return "\n"
     }
 
-    // note that if prev is an element node (inline or not), it'll handle the newline.
+    // note that if prev is an element/decorator node (inline or not), it'll handle the newline.
     return ""
   }
 

--- a/Lexical/Core/Nodes/ElementNode.swift
+++ b/Lexical/Core/Nodes/ElementNode.swift
@@ -324,6 +324,11 @@ open class ElementNode: Node {
       if let nextSiblingAsElement = nextSibling as? ElementNode, !nextSiblingAsElement.isInline() {
         // we're inline but the next sibling is an element but is not inline
         return "\n"
+      } else if let nextSiblingAsDecorator = nextSibling as? DecoratorNode,
+        !nextSiblingAsDecorator.isInline()
+      {
+        // we're inline but the next sibling is a decorator but is not inline
+        return "\n"
       } else {
         // we're inline, next sibling is either a text node or inline
         return ""

--- a/Lexical/Core/Nodes/ElementNode.swift
+++ b/Lexical/Core/Nodes/ElementNode.swift
@@ -304,7 +304,7 @@ open class ElementNode: Node {
       return ""
     }
 
-    guard prevSibling is ElementNode else {
+    guard prevSibling is ElementNode || prevSibling is DecoratorNode else {
       // prev is not an element node. Treat it as inline (TODO: inline handling in decorators)
       // Since prev is inline but not an element node, and we're not inline, return a newline
       return "\n"

--- a/Lexical/Core/Selection/RangeSelection.swift
+++ b/Lexical/Core/Selection/RangeSelection.swift
@@ -591,6 +591,25 @@ public class RangeSelection: BaseSelection {
     var didReplaceOrMerge = false
 
     for node in nodes {
+
+      if let node = node as? DecoratorNode {
+        if node == firstNode && node.isTopLevel() {
+          if let unwrappedTarget = target as? ElementNode,
+             unwrappedTarget.isEmpty() &&
+             unwrappedTarget.canReplaceWith(replacement: node) &&
+             isRootNode(node: unwrappedTarget.getParent()) {
+            try target.replace(replaceWith: node)
+            target = node
+            didReplaceOrMerge = true
+            continue
+          }
+        }
+
+        if isTextNode(target) {
+          target = topLevelElement
+        }
+      }
+
       if let node = node as? ElementNode {
         if node == firstNode {
           if let unwrappedTarget = target as? ElementNode,
@@ -665,8 +684,7 @@ public class RangeSelection: BaseSelection {
             target = try target.insertAfter(nodeToInsert: node)
           }
         }
-      } else if !isElementNode(node: node) ||
-                  isDecoratorNode(node) && (node as? DecoratorNode)?.isTopLevel() == true {
+      } else if isDecoratorNode(node) && (node as? DecoratorNode)?.isTopLevel() == true {
         target = try target.insertAfter(nodeToInsert: node)
       } else {
         target = try node.getParentOrThrow() // Re-try again with the target being the parent

--- a/Lexical/Core/Selection/RangeSelection.swift
+++ b/Lexical/Core/Selection/RangeSelection.swift
@@ -555,7 +555,9 @@ public class RangeSelection: BaseSelection {
     var siblings: [Node] = []
 
     let nextSiblings = anchorNode.getNextSiblings()
-    let topLevelElement = anchorNode.getTopLevelElementOrThrow()
+    guard let topLevelElement = anchorNode.getTopLevelElement() ?? (anchorNode as? ElementNode) else {
+      fatalError("Expected to find a top level element from anchor node \(anchorNode.key)")
+    }
 
     if let anchorNode = anchorNode as? TextNode {
       let textContent = anchorNode.getTextPart()


### PR DESCRIPTION
- inline and non-inline handling in decorator nodes (like how element nodes support `isInline()`)
- change access level of properties such as `isTopLevel` from `public` to `open` to allow overrides by decorator node subclasses outside of the package