### PR TITLE
Fix autolink URL logic

### DIFF
--- a/Plugins/LexicalAutoLinkPlugin/LexicalAutoLinkPlugin/AutoLinkPlugin.swift
+++ b/Plugins/LexicalAutoLinkPlugin/LexicalAutoLinkPlugin/AutoLinkPlugin.swift
@@ -140,7 +140,7 @@ open class AutoLinkPlugin: Plugin {
       let predicate = NSPredicate(format: "SELF MATCHES %@", argumentArray: [urlMatcher])
       if predicate.evaluate(with: String(subString)) {
         var newURLString = String(subString)
-        if !newURLString.hasPrefix("https://") || !newURLString.hasPrefix("http://") {
+        if !(newURLString.hasPrefix("https://") || !newURLString.hasPrefix("http://")) {
           newURLString = "https://" + newURLString
         }
 


### PR DESCRIPTION
Fixes a faulty conditional in the autolink link matcher where "https://" would be added to the autolink URL for any input