### PR TITLE
Placeholder text fixes

### DIFF
--- a/Lexical/Core/Selection/RangeSelection.swift
+++ b/Lexical/Core/Selection/RangeSelection.swift
@@ -759,6 +759,11 @@ public class RangeSelection: BaseSelection {
         }
       }
     }
+
+    if let editor = getActiveEditor() {
+      editor.frontend?.showPlaceholderText()
+    }
+
     return true
   }
 

--- a/Lexical/LexicalView/LexicalView.swift
+++ b/Lexical/LexicalView/LexicalView.swift
@@ -74,7 +74,7 @@ public extension LexicalViewDelegate {
 
     self.textView.lexicalDelegate = self
     if let placeholderText {
-      self.textView.setPlaceholderText(placeholderText.text, textColor: placeholderText.color, font: placeholderText.font)
+      self.textView.setPlaceholderText(placeholderText)
     }
 
     addSubview(self.textView)
@@ -263,11 +263,7 @@ public extension LexicalViewDelegate {
     set {
       _placeholderText = newValue
       if let _placeholderText {
-        textView.setPlaceholderText(
-          _placeholderText.text,
-          textColor: _placeholderText.color,
-          font: _placeholderText.font
-        )
+        textView.setPlaceholderText(_placeholderText)
       }
     }
   }

--- a/LexicalTests/Tests/TextViewTests.swift
+++ b/LexicalTests/Tests/TextViewTests.swift
@@ -303,7 +303,13 @@ class TextViewTests: XCTestCase {
   func testShowPlaceholderTextWithPlaceholderLabel() {
     let view = LexicalView(editorConfig: EditorConfig(theme: Theme(), plugins: []), featureFlags: FeatureFlags())
     let textView = view.textView
-    textView.setPlaceholderText("Enter Text", textColor: .lightGray, font: .systemFont(ofSize: 8))
+    textView.setPlaceholderText(
+      LexicalPlaceholderText(
+        text: "Enter Text",
+        font: .systemFont(ofSize: 8),
+        color: .lightGray
+      )
+    )
 
     if let label = textView.subviews.first(where: { $0 is UILabel }) as? UILabel {
       XCTAssertTrue(!label.isHidden)
@@ -314,7 +320,13 @@ class TextViewTests: XCTestCase {
     let view = LexicalView(editorConfig: EditorConfig(theme: Theme(), plugins: []), featureFlags: FeatureFlags())
     let textView = view.textView
 
-    textView.setPlaceholderText("Enter Text", textColor: .lightGray, font: .systemFont(ofSize: 8))
+    textView.setPlaceholderText(
+      LexicalPlaceholderText(
+        text: "Enter Text",
+        font: .systemFont(ofSize: 8),
+        color: .lightGray
+      )
+    )
     textView.insertText("hello")
     textView.showPlaceholderText()
 
@@ -326,7 +338,13 @@ class TextViewTests: XCTestCase {
   func testShowPlaceholderLabelOnDeletion() throws {
     let view = LexicalView(editorConfig: EditorConfig(theme: Theme(), plugins: []), featureFlags: FeatureFlags())
     let textView = view.textView
-    textView.setPlaceholderText("Aa", textColor: .lightGray, font: .systemFont(ofSize: 8))
+    textView.setPlaceholderText(
+      LexicalPlaceholderText(
+        text: "Aa",
+        font: .systemFont(ofSize: 8),
+        color: .lightGray
+      )
+    )
 
     textView.insertText("H")
     textView.showPlaceholderText()


### PR DESCRIPTION
- Make placeholder text label obey paragraph style line height
- Update placeholder text label on insert nodes
- Don't show placeholder text label if decorator nodes are present
- Refactor `setPlaceholderText` to take `LexicalPlaceholderText` as argument