### PR TITLE
Readonly view: link tapping improvements, fixes

### DIFF
--- a/Lexical/Core/Constants.swift
+++ b/Lexical/Core/Constants.swift
@@ -125,6 +125,7 @@ public struct CommandType: RawRepresentable, Hashable {
   public static let keyTab = CommandType(rawValue: "keyTab")
   public static let clearEditor = CommandType(rawValue: "clearEditor")
   public static let linkTapped = CommandType(rawValue: "linkTapped")
+  public static let entityTapped = CommandType(rawValue: "entityTapped")
   public static let truncationIndicatorTapped = CommandType(rawValue: "truncationIndicatorTapped")
   public static let readOnlyViewTapped = CommandType(rawValue: "readOnlyViewTapped")
   public static let indentContent = CommandType(rawValue: "indentContent")

--- a/Lexical/LexicalView/ReadOnly/LexicalReadOnlyTextKitContext.swift
+++ b/Lexical/LexicalView/ReadOnly/LexicalReadOnlyTextKitContext.swift
@@ -135,9 +135,10 @@ internal class LexicalReadOnlySizeCache {
   }
 
   private func setTextContainerSize(forWidth width: CGFloat, maxHeight: CGFloat?) {
-    if sizeCache.requiredWidth == width && sizeCache.requiredHeight == maxHeight {
-      return
-    }
+    // need to disable this for initial sizing to work
+    // if sizeCache.requiredWidth == width && sizeCache.requiredHeight == maxHeight {
+    //   return
+    // }
 
     createAndPropagateSizeCache()
     sizeCache.requiredWidth = width

--- a/Lexical/LexicalView/ReadOnly/LexicalReadOnlyView.swift
+++ b/Lexical/LexicalView/ReadOnly/LexicalReadOnlyView.swift
@@ -67,20 +67,29 @@ import UIKit
       }
     }
 
+    var partialFraction: CGFloat = 0
     let indexOfCharacter = textKitContext.layoutManager.characterIndex(for: pointInTextContainer,
                                                                        in: textKitContext.textContainer,
-                                                                       fractionOfDistanceBetweenInsertionPoints: nil)
+                                                                       fractionOfDistanceBetweenInsertionPoints: &partialFraction)
+
+    if indexOfCharacter == textKitContext.textStorage.length - 1 && partialFraction == 1.0 {
+      textKitContext.editor.dispatchCommand(type: .readOnlyViewTapped, payload: nil)
+      return
+    }
+
     let attributes = textKitContext.textStorage.attributes(at: indexOfCharacter, effectiveRange: nil)
 
-    if let link = attributes[.link] {
-      if let link = link as? URL {
+    if let entity = attributes[.link] {
+      if let link = entity as? URL {
         textKitContext.editor.dispatchCommand(type: .linkTapped, payload: link)
         return
-      } else if let link = link as? String {
+      } else if let link = entity as? String {
         if let linkURL = URL(string: link) {
           textKitContext.editor.dispatchCommand(type: .linkTapped, payload: linkURL)
           return
         }
+      } else {
+        textKitContext.editor.dispatchCommand(type: .entityTapped, payload: entity)
       }
     }
 


### PR DESCRIPTION
- Fixed a bug where tapping on empty space after a link node as the last node would trigger a tap
- Added `entityTapped` command type to support tapping of generic text nodes with a `.link` attribute
- Disabled an optimization? that would mistakenly skip initial sizing