### PR TITLE
Fix insert issue on with decorators on empty state

### DIFF
--- a/Lexical/Core/Selection/RangeSelection.swift
+++ b/Lexical/Core/Selection/RangeSelection.swift
@@ -537,6 +537,10 @@ public class RangeSelection: BaseSelection {
       try removeText()
     }
 
+    if isRootNode(node: try anchor.getNode()) {
+      try removeText()
+    }
+
     let anchor = anchor
     let anchorOffset = anchor.offset
     let anchorNode = try anchor.getNode()
@@ -593,7 +597,6 @@ public class RangeSelection: BaseSelection {
     var didReplaceOrMerge = false
 
     for node in nodes {
-
       if let node = node as? DecoratorNode {
         if node == firstNode && node.isTopLevel() {
           if let unwrappedTarget = target as? ElementNode,


### PR DESCRIPTION
If the editor state is simply a root node with no children, inserting a decorator node won't work. This fixes the issue by calling `removeText` (essentially inserting an empty paragraph) if inserting nodes while the root node is the anchor.